### PR TITLE
Blockscout - Nova linha necessária para funcionar atualmente (aplicação não subia/quebrou)

### DIFF
--- a/artefatos/observer/blockscout/docker-compose/envs/common-stats.env
+++ b/artefatos/observer/blockscout/docker-compose/envs/common-stats.env
@@ -25,3 +25,5 @@ STATS__JAEGER__AGENT_ENDPOINT=localhost:6831
 
 STATS__TRACING__ENABLED=true
 STATS__TRACING__FORMAT=default
+
+STATS__BLOCKSCOUT_API_URL=http://host.docker.internal


### PR DESCRIPTION
Após horas tentando entender o que havia quebrado a instalação fluída do Blockscout, tive a surpresa de que esta linha passou a ser necessária para que o container "stats" não fique reiniciando, e assim o frontend recebe 502 bad gateway, não conseguindo mostrar o gráfico da blockchain (quebra total da interface).

![image](https://github.com/user-attachments/assets/2534a372-1df5-41da-839d-36010972110a)

![image](https://github.com/user-attachments/assets/90260341-6c8f-4235-8434-ad28a0f810f4)
